### PR TITLE
Update to reset_origin(); new functions for handling mass weighted Cartesian coordinates

### DIFF
--- a/FOX/functions/multi_mol_magic.py
+++ b/FOX/functions/multi_mol_magic.py
@@ -102,6 +102,12 @@ class _MultiMolecule:
     def _get_dtype(self): return self.coords.nbytes
     nbytes = property(_get_dtype)
 
+    def _transpose(self):
+        ret = self.copy()
+        ret.coords = self.T
+        return ret
+    T = property(_transpose)
+
     """ ############################  Comparison magic methods  ############################### """
 
     def __eq__(self, other):
@@ -245,7 +251,7 @@ class _MultiMolecule:
         return self
 
     def __imatmul__(self, other):
-        self.coords = self.coords @ np.swapaxes(other, -2, -1)
+        self.coords = self.coords @ other
         return self
 
     def __ifloordiv__(self, other):
@@ -322,7 +328,7 @@ class _MultiMolecule:
     def __getitem__(self, key):
         if not isinstance(key, str):
             return self.coords[key]
-        return self.atoms[key]
+        return self.atoms[key.capitalize()]
 
     def __setitem__(self, key, value):
         self.coords[key] = value

--- a/docs/MultiMolecule.rst
+++ b/docs/MultiMolecule.rst
@@ -7,6 +7,7 @@ API
 .. autoclass:: FOX.functions.multi_mol.MultiMolecule
     :members:
 
+.. _PeriodicTable: https://www.scm.com/doc/plams/components/utils.html#periodic-table
 .. _plams.Settings: https://www.scm.com/doc/plams/components/settings.html
 .. _plams.Molecule: https://www.scm.com/doc/plams/components/molecule.html#id1
 .. _np.ndarray: https://docs.scipy.org/doc/numpy/reference/generated/numpy.ndarray.html


### PR DESCRIPTION
- reset_origin() now accounts for both translations and rotations, [issue #12]( https://github.com/BvB93/auto-FOX/issues/12#issue-413314010).
- Introduced new functions for converting to and from mass weighted Cartesian coordinates
- Introduced a new function for extracting atomic properties from the PLAMS PeriodicTable module.